### PR TITLE
Исправлена ошибка в имени модели

### DIFF
--- a/ru/foundation-models/tuning/api-ref/grpc/Tuning/tune.md
+++ b/ru/foundation-models/tuning/api-ref/grpc/Tuning/tune.md
@@ -155,7 +155,7 @@ sourcePath: en/_api-ref-grpc/ai/tuning/v1/tuning/api-ref/grpc/Tuning/tune.md
 ||Field | Description ||
 || base_model_uri | **string**
 
-Required field. Format like a gpt://{folder_id}/yandex-gpt/latest ||
+Required field. Format like a gpt://{folder_id}/yandexgpt/latest ||
 || train_datasets[] | **[WeightedDataset](#yandex.cloud.ai.tuning.v1.TuningRequest.WeightedDataset)** ||
 || validation_datasets[] | **[WeightedDataset](#yandex.cloud.ai.tuning.v1.TuningRequest.WeightedDataset)** ||
 || text_to_text_completion | **[TextToTextCompletionTuningParams](#yandex.cloud.ai.tuning.v1.TextToTextCompletionTuningParams)**


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

Модель называется `yandexgpt`. При обращении к ней ошибок нет, а вот `yandex-gpt` возвращает следующее:

```
 ERROR:
  Code: NotFound
  Message: NOT_FOUND: Model not found: gpt://yandex-gpt/latest
```

Да, в ответе от сервера скрывается значение параметра `folder_id` при том, что в самом запросе он присутствует.